### PR TITLE
agy 1.0.9: console-detach leak fix, streaming progress, AGY_BIN fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ Personal project, **best-effort maintenance** — issues and PRs welcome, but no
 promises. If `agy -p` ever starts printing to stdout correctly, this whole repo becomes a fun
 historical artefact.
 
+## 🌐 Community & Acknowledgments
+
+- **Qiita (Japan):** A huge thanks to `@fallout` and the Japanese developer community for featuring this project and providing invaluable feedback!
+  - [Detailed Hybrid Setup Guide (Claude Code × Antigravity CLI)](https://qiita.com/fallout/items/5097f0575b58f4c69b81)
+  - [Quick Installation Guide](https://qiita.com/fallout/items/d699df3d6931c07eb38d)
+
+> 💡 **Path Resolution Fix:** Thanks to their community's real-world testing, we identified and resolved a Windows PATH edge case where the MCP server inherits a *stale* `PATH` at startup and can't find `agy`. The `AGY_BIN` environment-variable fallback was implemented directly inspired by their report!
+
 ## License
 
 [MIT](LICENSE). Do whatever you want with it.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![MCP server](https://img.shields.io/badge/MCP-server-7c3aed)](https://modelcontextprotocol.io/)
-[![agy 1.0.8 verified](https://img.shields.io/badge/agy-1.0.8%20verified-2ea44f)](https://antigravity.google/)
+[![agy 1.0.9 verified](https://img.shields.io/badge/agy-1.0.9%20verified-2ea44f)](https://antigravity.google/)
 [![platform](https://img.shields.io/badge/platform-Windows%20·%20macOS%20·%20Linux-lightgrey)](#requirements)
 
 </div>
@@ -16,10 +16,12 @@
 ---
 
 `agy`, Google's Antigravity CLI, ships a headless print mode (`agy -p`) that's **broken**: it
-authenticates, talks to the model, gets the answer back… and then never prints it. This bridge
-runs `agy -p` anyway, reads the answer straight out of agy's *own* transcript files, and hands it
-to Claude Code as clean MCP tools. Delegate cheap tool-calling work to Gemini without leaving
-your terminal.
+authenticates, talks to the model, gets the answer back… and then writes it to the *controlling
+terminal* instead of its stdout — so anything capturing stdout gets nothing (and, run under a TUI,
+agy's text leaks straight into the host's prompt). This bridge runs `agy -p` anyway, **detaches it
+from your terminal** so it can't leak, reads the answer straight out of agy's *own* transcript
+files, and hands it to Claude Code as clean MCP tools. Delegate cheap tool-calling work to Gemini
+without leaving your terminal.
 
 > [!WARNING]
 > **This runs unsandboxed code with your privileges.** `agy -p` auto-executes its tools
@@ -47,12 +49,12 @@ flowchart LR
     B -- "agy -p prompt" --> C[Antigravity CLI]
     C -- "Gemini 3.5 Flash (High)" --> M((model))
     M -- "answer" --> C
-    C -. "writes (but never prints)" .-> T[("transcript.jsonl")]
+    C -. "writes (stdout stays empty)" .-> T[("transcript.jsonl")]
     B -- "reads final PLANNER_RESPONSE" --> T
     B -- "plain text" --> A
 ```
 
-`agy -p` persists its real answer — the one it forgets to print — to:
+`agy -p` persists its real answer — the one it never sends to stdout — to:
 
 ```
 ~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript.jsonl
@@ -103,7 +105,7 @@ using the absolute path to `server.py`:
 </td></tr>
 </table>
 
-Restart Claude Code. Four tools appear: **`mcp__agy__agy_ask`**, **`mcp__agy__agy_continue`**, **`mcp__agy__agy_status`**, and **`mcp__agy__agy_image`**.
+Restart Claude Code. Five tools appear: **`mcp__agy__agy_ask`**, **`mcp__agy__agy_continue`**, **`mcp__agy__agy_ask_stream`**, **`mcp__agy__agy_status`**, and **`mcp__agy__agy_image`**.
 
 > *"Use agy_ask to summarize the README of this repo in three bullets."* → Claude routes the prompt
 > through the bridge, agy reads the file under the workspace root, and the answer comes back as a
@@ -115,6 +117,7 @@ Restart Claude Code. Four tools appear: **`mcp__agy__agy_ask`**, **`mcp__agy__ag
 |---|---|
 | `agy_ask(prompt, workspace?, timeout_s?=180)` | Start a **new** Antigravity conversation. |
 | `agy_continue(prompt, workspace?, timeout_s?=180)` | Continue the conversation **rooted at `workspace`** (pinned by id). |
+| `agy_ask_stream(prompt, workspace?, timeout_s?=180)` | 🧪 **Experimental.** Like `agy_ask`, but emits agy's intermediate steps as MCP **progress notifications** while it works (coarse — see [FAQ](#faq)). |
 | `agy_status()` | Offline setup diagnostics (agy version/compat, state dirs, newest transcript readable). Spends no quota. |
 | `agy_image(prompt, output_path?, workspace?, timeout_s?=240)` | Generate an image with Antigravity; saves the file (extension corrected to the real bytes) and returns its path + format/size. |
 
@@ -148,7 +151,7 @@ format.
 `agy -p` runs the model as an **autonomous agent that auto-executes its own tools** — reading and
 writing files, running shell commands, and reaching the network — with **no approval gate and no
 opt-out**. This isn't a choice the bridge makes; it's how agy's print mode works. Re-verified
-empirically on **agy 1.0.8 / Windows**:
+empirically on **agy 1.0.9 / Windows** (all three checks below still hold):
 
 - Print mode runs out-of-workspace file writes and live network fetches **even without**
   `--dangerously-skip-permissions` — that flag is a **no-op** for `-p`. There is **no** agy flag
@@ -158,11 +161,13 @@ empirically on **agy 1.0.8 / Windows**:
   workspace with no prompt.
 - `--sandbox` is **not** a usable boundary. agy 1.0.6 fixed its propagation into `-p` (the 1.0.6/1.0.7
   changelog calls this "sandbox isolation correctly enforced") and it now **does** block terminal/
-  shell command execution — but verified here that it leaves the `write_to_file` tool and network
-  **wide open**: under `--sandbox` the model still wrote a file *outside* its workspace, and its own
-  permission dump showed `command(*)` / `execute_url(*)` / `read_url(*)` all `allowed`. On top of
-  that, a `--sandbox` run whose blocked terminal command halts it writes **no JSONL transcript**, so
-  the bridge couldn't read a response — so the bridge deliberately never passes `--sandbox`.
+  shell command execution — but re-verified on 1.0.9 that it leaves the `write_to_file` tool and
+  network **wide open**: under `--sandbox` the model still wrote a file *outside* its workspace. agy
+  1.0.9 hardened the sandbox's *command* path (stricter exact-match command checks; `.git` added to
+  its dangerous-paths list), but none of that closes the out-of-workspace `write_to_file` hole. On
+  top of that, a `--sandbox` run whose blocked terminal command halts it writes **no JSONL
+  transcript** (only the SQLite `.db`, re-confirmed on 1.0.9), so the bridge couldn't read a
+  response — so the bridge deliberately never passes `--sandbox`.
 
 **What that means for you:**
 
@@ -190,11 +195,11 @@ apply, and you're responsible for staying within them.
 <summary><b>Will it break when agy updates?</b></summary>
 
 Possibly — it reads agy's **internal, undocumented** state files, so a release can change paths or
-schemas and break it silently. Re-verified working on **1.0.8** (transcript schema and `-p` JSONL
-output unchanged; live smoke test passes). The known future risk is agy's **SQLite (`.db`)
-conversation format** (added in 1.0.4, slated to become the default): agy 1.0.8 already
-**dual-writes** every conversation to `~/.gemini/antigravity-cli/conversations/<id>.db` alongside
-the JSONL transcript, so once it stops writing JSONL the reader needs a SQLite path. Pin a
+schemas and break it silently. Re-verified working on **1.0.9** (transcript schema and `-p` JSONL
+output unchanged; live ask/continue/image round-trips pass). The known future risk is agy's
+**SQLite (`.db`) conversation format** (added in 1.0.4, slated to become the default): agy 1.0.9
+still **dual-writes** every conversation to `~/.gemini/antigravity-cli/conversations/<id>.db`
+alongside the JSONL transcript, so once it stops writing JSONL the reader needs a SQLite path. Pin a
 known-good `agy` version if you depend on this.
 </details>
 
@@ -213,7 +218,7 @@ would hang on any real switch.
 **Yes — that's the `agy_image` tool.** agy's print mode generates real images on
 your AI Pro quota; `agy_image` drives it, saves the file to a path you choose (or
 a timestamped default in your workspace), fixes the extension to match the real
-bytes (agy picks JPEG or PNG itself), and returns the path. Verified on **agy 1.0.8 / Windows**.
+bytes (agy picks JPEG or PNG itself), and returns the path. Verified on **agy 1.0.9 / Windows**.
 It's request/response only and runs a normal, unsandboxed agy session (see
 [Security](#security)).
 </details>
@@ -228,7 +233,14 @@ amount.
 <details>
 <summary><b>Does it stream responses?</b></summary>
 
-No. `agy -p` is request/response only, so the bridge is too. Each call typically takes 10–30 s.
+The final answer is request/response — `agy -p` returns it all at once, so `agy_ask`/`agy_continue`
+do too (each call typically takes 10–30 s). But there's an **experimental** `agy_ask_stream` that
+reports agy's *intermediate* steps as MCP **progress notifications** while it works, read live from
+agy's transcript. It's deliberately **coarse**: agy flushes its transcript in chunks (observed on
+1.0.9: it can sit empty for ~15 s, then append several steps at once), so you get a handful of
+progress ticks — agy's planner narration and tool runs — not token-by-token streaming. Whether you
+*see* the ticks depends on your MCP client surfacing progress/log notifications; the returned text is
+identical to `agy_ask`.
 </details>
 
 <details>
@@ -241,15 +253,22 @@ requests queue rather than race — plan latency accordingly under load.
 
 ## Status & caveats
 
-- ✅ **Verified on agy 1.0.8** — base dir, `last_conversations.json`, the
+- ✅ **Verified on agy 1.0.9** — base dir, `last_conversations.json`, the
   `brain/.../transcript.jsonl` path, the transcript schema, and the `-p`/`-c`/`--print-timeout`
-  flags are all unchanged; a live smoke test passes all three round-trips (text ask/continue plus
-  image generation). The 1.0.5 `-p` metadata fix also means agy no longer litters the workspace dir.
-- ⏳ **SQLite migration is the real risk** — agy 1.0.8 already dual-writes a `.db` per conversation;
+  flags are all unchanged; live ask/continue/image round-trips all pass. The 1.0.5 `-p` metadata fix
+  also means agy no longer litters the workspace dir.
+- 🖥️ **Console-detach (new)** — agy `-p` writes its progress/answer to the *controlling terminal*,
+  not stdout; under a TUI that text leaks into the host's prompt (seen on 1.0.9 before the fix). The
+  bridge now spawns agy detached from the terminal (`CREATE_NO_WINDOW` / a new POSIX session), so it
+  can't leak; the answer is still read from the transcript.
+- ⏳ **SQLite migration is the real risk** — agy 1.0.9 still dual-writes a `.db` per conversation;
   see the [FAQ](#faq). `_read_response` raises a clear, SQLite-aware error if the JSONL transcript
   ever disappears.
-- 🐛 **Stdout bug** — `-p` still doesn't print the answer on 1.0.8. If a future release fixes
-  stdout, this workaround becomes redundant but harmless.
+- 🐛 **Stdout bug persists** — `-p` still doesn't print the answer to stdout on 1.0.9 (the 1.0.9
+  "print-mode resumption" changelog fix did **not** change this for fresh `-p`). If a future release
+  fixes stdout, this workaround becomes redundant but harmless.
+- 🧪 **Streaming is experimental** — `agy_ask_stream` surfaces coarse progress only; see the
+  [FAQ](#faq).
 - 🔒 **No real sandbox** — agy's `--sandbox` (since 1.0.6) blocks only shell commands in `-p` but still
   leaves file writes and network egress open (and breaks transcript reading), so it's no boundary;
   see [Security](#security).
@@ -257,7 +276,7 @@ requests queue rather than race — plan latency accordingly under load.
 ## Requirements
 
 - Python 3.10+
-- [`agy`](https://antigravity.google/) 1.0.0 or newer on `PATH` (state-file layout re-verified on **1.0.8**)
+- [`agy`](https://antigravity.google/) 1.0.0 or newer on `PATH` (state-file layout re-verified on **1.0.9**)
 - An active Antigravity / AI Pro session
 
 The bridge uses only cross-platform Python (`Path.home()`, `subprocess`) and reads paths under

--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ requests queue rather than race — plan latency accordingly under load.
 - [`agy`](https://antigravity.google/) 1.0.0 or newer on `PATH` (state-file layout re-verified on **1.0.9**)
 - An active Antigravity / AI Pro session
 
+> [!TIP]
+> If `agy` isn't reliably on `PATH` (e.g. a new terminal or reboot drops it on Windows), set the
+> **`AGY_BIN`** env var to its full path and the bridge will use that instead of `"agy"` — e.g.
+> `AGY_BIN=%LOCALAPPDATA%\agy\bin\agy.exe`.
+
 The bridge uses only cross-platform Python (`Path.home()`, `subprocess`) and reads paths under
 `~/.gemini/antigravity-cli/`, which `agy` writes the same way on every OS. **Developed and verified
 on Windows; macOS and Linux should work unmodified provided `agy -i` runs there.** If you test it on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agy-mcp-server"
-version = "0.4.2"
+version = "0.5.0"
 description = "MCP server bridging Antigravity CLI (agy) so Claude Code can use it as a sub-agent"
 requires-python = ">=3.10"
 dependencies = [

--- a/server.py
+++ b/server.py
@@ -1,11 +1,16 @@
 """Antigravity CLI (agy) bridge — fastmcp server.
 
 Exposes Antigravity CLI as MCP tools so Claude Code (or any MCP host) can
-use it as a sub-agent. Solves the headless print-mode bug in agy 1.0.x
-(verified broken through 1.0.1; -p still does not print the answer on 1.0.8)
-by running `agy -p` and reading the response from agy's own transcript files
-instead of relying on stdout. State-file layout and transcript schema
-re-verified on agy 1.0.8.
+use it as a sub-agent. Solves the headless print-mode "stdout bug" in agy
+1.0.x (verified broken through 1.0.9): `agy -p` writes its progress/answer to
+the controlling terminal (TTY/console) directly, NOT to its stdout file
+descriptor — so a captured-stdout read gets nothing. The bridge runs `agy -p`
+and reads the real response from agy's own transcript files instead. It also
+detaches agy from the host's controlling terminal when spawning it (see
+_spawn_kwargs), so that direct-to-terminal output can't leak into the host TUI
+— e.g. straight into Claude Code's prompt input (observed empirically on 1.0.9
+before the fix). State-file layout and transcript schema re-verified on agy
+1.0.9.
 
 Auth: piggybacks on whatever credential store `agy` itself uses on the host
 OS (Windows Credential Manager, macOS Keychain, libsecret on Linux). User
@@ -22,7 +27,7 @@ to wait on an interactive/backend step it never gets headless). So the bridge
 does NOT expose a model parameter — it would hang on any real switch. Change
 the model via agy's settings.json instead.
 
-Compat (re-verified on agy 1.0.8): state-file paths, last_conversations.json,
+Compat (re-verified on agy 1.0.9): state-file paths, last_conversations.json,
 and the transcript schema are unchanged, and a normally-completing -p run still
 writes the JSONL transcript this bridge reads. agy now ALSO dual-writes every
 conversation to a SQLite store at ~/.gemini/antigravity-cli/conversations/<id>.db;
@@ -36,7 +41,7 @@ the cwd, so last_conversations.json now updates reliably under cache/.
 SECURITY — read this: `agy -p` runs the model as an autonomous agent that
 auto-executes its tools (read/write files, run shell commands, reach the
 network) with NO approval gate and NO opt-out. Re-verified empirically on
-agy 1.0.8 / Windows that print mode runs out-of-workspace writes even WITHOUT
+agy 1.0.9 / Windows that print mode runs out-of-workspace writes even WITHOUT
 --dangerously-skip-permissions (that flag is a no-op for -p). agy 1.0.5
 integrated a permission system (its logs show toolPermission=request-review),
 but it still does NOT gate print-mode tool execution — -p created a file
@@ -46,12 +51,14 @@ outside the workspace with no prompt.
 --sandbox flag propagation into -p (its 1.0.6 changelog calls this "sandbox
 isolation correctly enforced"), and verified here it now DOES block terminal/
 shell command execution in print mode. But that "isolation" is partial and
-misleadingly named: under --sandbox the model still wrote a file OUTSIDE its
-workspace via the write_to_file tool, and its own permission dump showed
-command(*)/execute_url(*)/read_url(*) all "allowed" — so --sandbox does NOT
-constrain filesystem writes or network egress, only the terminal. Worse for
-us, a --sandbox run that hits a blocked terminal command writes NO JSONL
-transcript (only the SQLite .db), so the bridge would fail to read a response.
+misleadingly named: re-verified on 1.0.9 that under --sandbox the model still
+wrote a file OUTSIDE its workspace via the write_to_file tool — so --sandbox
+does NOT constrain filesystem writes or network egress, only the terminal.
+(agy 1.0.9 hardened the sandbox's command path — stricter exact-match command
+checks, .git added to its dangerous-paths list — but none of that closes the
+out-of-workspace write_to_file hole.) Worse for us, a --sandbox run that hits
+a blocked terminal command writes NO JSONL transcript (only the SQLite .db, as
+re-confirmed on 1.0.9), so the bridge would fail to read a response.
 For both reasons the bridge deliberately does NOT pass --sandbox; there is
 still no agy flag that makes print mode safe.
 
@@ -71,9 +78,10 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
-from fastmcp import FastMCP
+import anyio
+from fastmcp import Context, FastMCP
 
 mcp = FastMCP("agy")
 
@@ -96,13 +104,19 @@ _AGY_LOCK = threading.Lock()
 # Latest agy version the bridge's state-file assumptions were verified against.
 # Newer agy releases may change paths/schemas (the SQLite migration is the known
 # risk), so we warn at startup if the installed agy is newer than this.
-VERIFIED_AGY_VERSION = (1, 0, 8)
+VERIFIED_AGY_VERSION = (1, 0, 9)
 
 # Poll window for the transcript/conversation-id to appear after agy exits.
 # agy has already returned 0 by the time we read, so the common case resolves
 # on the first attempt; the poll just absorbs filesystem-flush lag.
 _RESPONSE_POLL_DEADLINE_S = 5.0
 _RESPONSE_POLL_INTERVAL_S = 0.1
+
+# How often the streaming runner re-reads the transcript to emit progress while
+# agy is still working. agy flushes the transcript in coarse chunks (verified on
+# 1.0.9: it can stay empty for ~15 s then append several entries at once), so
+# progress is deliberately coarse — a handful of ticks per run, not token-level.
+_PROGRESS_POLL_INTERVAL_S = 0.4
 
 
 def _parse_agy_version(text: str) -> Optional[tuple[int, int, int]]:
@@ -140,6 +154,24 @@ def _debug_enabled() -> bool:
     }
 
 
+def _spawn_kwargs() -> dict:
+    """Extra subprocess kwargs that detach agy from the host's controlling terminal.
+
+    agy -p writes its progress/answer to the controlling terminal (TTY/console)
+    directly, NOT to its stdout file descriptor — which is both why capturing
+    stdout yields nothing AND why, when run under an interactive terminal, agy's
+    text leaks into the host (e.g. straight into Claude Code's TUI prompt input).
+    Detaching gives agy no terminal to write to; the bridge still reads the real
+    answer from the transcript file. Verified on agy 1.0.9 / Windows that this
+    does not change what the bridge captures (the response is read from the
+    transcript regardless). Windows: CREATE_NO_WINDOW. POSIX: a new session
+    (no controlling tty).
+    """
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}
+    return {"start_new_session": True}
+
+
 def _get_agy_version() -> Optional[str]:
     """Return `agy --version` output, or None if agy can't be run."""
     try:
@@ -149,6 +181,7 @@ def _get_agy_version() -> Optional[str]:
             capture_output=True,
             text=True,
             timeout=15,
+            **_spawn_kwargs(),
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -252,6 +285,48 @@ def _read_response(conv_id: str) -> str:
         )
     # Last completed planner response is the final answer (tool steps come earlier).
     return chunks[-1]
+
+
+def _transcript_entries(conv_id: str) -> list[dict]:
+    """All parsed JSONL entries for a conversation, or [] if no transcript yet.
+
+    Unlike _read_response this is non-raising and returns every entry (not just
+    the final answer) — it's the live feed the streaming runner polls for
+    progress. Re-reads the whole file each call; transcripts are small (a handful
+    of entries per turn), so that's cheap enough for the poll loop.
+    """
+    transcript = BRAIN_DIR / conv_id / ".system_generated" / "logs" / "transcript.jsonl"
+    if not transcript.exists():
+        return []
+    out: list[dict] = []
+    for line in transcript.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _entry_to_progress(entry: dict) -> Optional[str]:
+    """One-line human progress string for a transcript entry, or None to skip.
+
+    Only the model's own steps are surfaced: PLANNER_RESPONSE (the narration agy
+    writes as it works — the exact text that used to leak to the host terminal)
+    and RUN_COMMAND (a tool step). USER_INPUT / CONVERSATION_HISTORY / system
+    rows are skipped. The final PLANNER_RESPONSE is also the answer, so callers
+    get the last narration line as a 'finishing' tick — harmless.
+    """
+    if entry.get("source") != "MODEL":
+        return None
+    etype = entry.get("type")
+    content = entry.get("content")
+    if etype == "PLANNER_RESPONSE" and content:
+        return content.strip().splitlines()[0][:160]
+    if etype == "RUN_COMMAND":
+        return "running a command…"
+    return None
 
 
 # Canonical extension per detected image format. Drives extension-correction:
@@ -447,16 +522,20 @@ def _resolve_and_read(pinned_conv: Optional[str], workspace: str, start: float) 
     return _read_response(conv_id)
 
 
-def _run_agy(prompt: str, workspace: str, continue_conv: bool, timeout_s: int) -> str:
-    # Note: agy's `-p` mode auto-executes all tools/commands with no approval
-    # gate, so we deliberately do NOT pass --dangerously-skip-permissions (it is
-    # a no-op for -p) or --sandbox. On 1.0.6+ --sandbox blocks only terminal/shell
-    # commands, not write_to_file/FS or network egress, so it is no real boundary;
-    # and a sandbox-blocked terminal run writes no JSONL transcript for us to read.
-    # There is no agy flag that makes print mode safe; see the module docstring's
-    # SECURITY note.
-    args = ["agy", "--print-timeout", f"{timeout_s}s"]
+def _build_agy_args(
+    prompt: str, workspace: str, continue_conv: bool, timeout_s: int
+) -> tuple[list[str], Optional[str]]:
+    """Build agy's argv and resolve the pinned conversation id for continue mode.
 
+    Note: agy's `-p` mode auto-executes all tools/commands with no approval gate,
+    so we deliberately do NOT pass --dangerously-skip-permissions (a no-op for -p)
+    or --sandbox. On 1.0.6+ --sandbox blocks only terminal/shell commands, not
+    write_to_file/FS or network egress, so it is no real boundary; and a
+    sandbox-blocked terminal run writes no JSONL transcript for us to read. There
+    is no agy flag that makes print mode safe; see the module docstring's SECURITY
+    note.
+    """
+    args = ["agy", "--print-timeout", f"{timeout_s}s"]
     pinned_conv: Optional[str] = None
     if continue_conv:
         # Pin to the exact conversation rooted at this workspace instead of `-c`
@@ -468,6 +547,11 @@ def _run_agy(prompt: str, workspace: str, continue_conv: bool, timeout_s: int) -
         else:
             args.append("-c")
     args.extend(["-p", prompt])
+    return args, pinned_conv
+
+
+def _run_agy(prompt: str, workspace: str, continue_conv: bool, timeout_s: int) -> str:
+    args, pinned_conv = _build_agy_args(prompt, workspace, continue_conv, timeout_s)
 
     with _AGY_LOCK:
         start = time.time()
@@ -486,6 +570,7 @@ def _run_agy(prompt: str, workspace: str, continue_conv: bool, timeout_s: int) -
             capture_output=True,
             text=True,
             timeout=timeout_s + 30,
+            **_spawn_kwargs(),  # keep agy's TTY writes out of the host terminal
         )
         log.debug("agy exited %s in %.1fs", proc.returncode, time.time() - start)
         if proc.returncode != 0:
@@ -507,6 +592,128 @@ def _run_agy(prompt: str, workspace: str, continue_conv: bool, timeout_s: int) -
                 # _read_response) is caught here too and surfaces only after the
                 # deadline; that small delay is an accepted tradeoff for keeping
                 # this loop simple.
+                if time.time() >= deadline:
+                    raise
+                time.sleep(_RESPONSE_POLL_INTERVAL_S)
+
+
+def _existing_conv_names() -> set[str]:
+    """Names of brain conversation dirs that exist right now (snapshot)."""
+    if not BRAIN_DIR.exists():
+        return set()
+    return {c.name for c in BRAIN_DIR.iterdir() if c.is_dir()}
+
+
+def _newest_new_conv(start: float, exclude: set[str]) -> Optional[str]:
+    """Newest brain dir touched since `start` whose name is NOT in `exclude`.
+
+    Used to lock streaming onto *this* run's brand-new conversation, ignoring any
+    other recently-finished one — without this, agy's initial blind window (the
+    transcript can stay empty ~15 s) would resolve to a prior conversation and
+    emit its steps as if they were ours.
+    """
+    if not BRAIN_DIR.exists():
+        return None
+    best, best_mtime = None, start - 2
+    for child in BRAIN_DIR.iterdir():
+        if not child.is_dir() or child.name in exclude:
+            continue
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > best_mtime:
+            best, best_mtime = child.name, mtime
+    return best
+
+
+class _ProgressStream:
+    """Emits transcript steps for ONE conversation, each new step exactly once.
+
+    For a continued conversation the id is pinned up front and the cursor starts
+    past the existing history (so prior turns aren't replayed — the same problem
+    agy 1.0.9 fixed for stdout). For a new conversation the id is unknown at
+    launch, so the stream locks onto the first brain dir that appears after launch
+    and didn't pre-exist, and never switches away from it.
+    """
+
+    def __init__(
+        self,
+        pinned_conv: Optional[str],
+        start: float,
+        on_progress: Callable[[int, str], None],
+    ) -> None:
+        self._start = start
+        self._on_progress = on_progress
+        self._pre_existing = set() if pinned_conv else _existing_conv_names()
+        self._conv = pinned_conv
+        self._cursor = len(_transcript_entries(pinned_conv)) if pinned_conv else 0
+
+    def poll(self) -> None:
+        """Read the locked conversation and emit any steps past the cursor."""
+        if self._conv is None:
+            self._conv = _newest_new_conv(self._start, self._pre_existing)
+            if self._conv is None:
+                return
+            self._cursor = 0
+        entries = _transcript_entries(self._conv)
+        for idx, entry in enumerate(entries[self._cursor :], start=self._cursor):
+            msg = _entry_to_progress(entry)
+            if msg:
+                self._on_progress(idx + 1, msg)
+        self._cursor = max(self._cursor, len(entries))
+
+
+def _run_agy_streamed(
+    prompt: str,
+    workspace: str,
+    continue_conv: bool,
+    timeout_s: int,
+    on_progress: Callable[[int, str], None],
+) -> str:
+    """Like _run_agy, but spawn agy non-blocking and stream transcript progress.
+
+    EXPERIMENTAL. Polls the transcript while agy works and calls
+    `on_progress(step, message)` for each new model step. Progress is coarse —
+    agy flushes the transcript in chunks (see _PROGRESS_POLL_INTERVAL_S) — so
+    expect a handful of ticks per run, with an initial blind window, not
+    token-level streaming. The final answer is still read from the transcript
+    exactly as _run_agy does.
+    """
+    args, pinned_conv = _build_agy_args(prompt, workspace, continue_conv, timeout_s)
+
+    with _AGY_LOCK:
+        start = time.time()
+        stream = _ProgressStream(pinned_conv, start, on_progress)
+        log.debug("streaming agy: pinned=%s", pinned_conv)
+        proc = subprocess.Popen(
+            args,
+            cwd=workspace,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            **_spawn_kwargs(),  # keep agy's TTY writes out of the host terminal
+        )
+        hard_deadline = start + timeout_s + 30
+        while proc.poll() is None:
+            if time.time() > hard_deadline:
+                proc.kill()
+                raise RuntimeError(f"agy timed out after {timeout_s + 30}s (streaming)")
+            stream.poll()
+            time.sleep(_PROGRESS_POLL_INTERVAL_S)
+
+        # Drain any entries flushed between the last poll and exit.
+        stream.poll()
+        _, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"agy exited {proc.returncode}\nstderr: {(stderr or '')[-1000:]}")
+
+        deadline = time.time() + _RESPONSE_POLL_DEADLINE_S
+        while True:
+            try:
+                return _resolve_and_read(pinned_conv, workspace, start)
+            except RuntimeError:
                 if time.time() >= deadline:
                     raise
                 time.sleep(_RESPONSE_POLL_INTERVAL_S)
@@ -548,6 +755,49 @@ def agy_continue(prompt: str, workspace: Optional[str] = None, timeout_s: int = 
     """
     ws = _normalize_workspace(workspace)
     return _run_agy(prompt, ws, continue_conv=True, timeout_s=timeout_s)
+
+
+@mcp.tool()
+def agy_ask_stream(
+    prompt: str,
+    workspace: Optional[str] = None,
+    timeout_s: int = 180,
+    ctx: Context = None,
+) -> str:
+    """EXPERIMENTAL: like agy_ask, but stream agy's progress while it works.
+
+    Starts a NEW conversation and returns the same final text as agy_ask, but as
+    agy works it reports each intermediate step — its planner narration (the same
+    text that, pre-fix, leaked into the host terminal) and its tool runs — as MCP
+    progress notifications, read live from agy's transcript.
+
+    Progress is intentionally coarse: agy flushes its transcript in chunks, so
+    expect a few ticks per run with an initial blind window, not token-level
+    streaming. Whether you SEE the ticks depends on your MCP client surfacing
+    progress/log notifications; the final return value is identical to agy_ask.
+
+    Args:
+        prompt: Question or instruction for Antigravity.
+        workspace: Working directory for the conversation. Defaults to cwd.
+        timeout_s: Max seconds to wait for agy to complete. Default 180.
+    """
+    ws = _normalize_workspace(workspace)
+
+    def emit(step: int, message: str) -> None:
+        if ctx is None:
+            return
+        # Bridge from this worker thread into the event loop to fire the async
+        # notifications. Best-effort: a progress hiccup must never fail the call.
+        try:
+            anyio.from_thread.run(ctx.report_progress, float(step), None, message)
+        except Exception:  # noqa: BLE001 - progress is best-effort
+            pass
+        try:
+            anyio.from_thread.run(ctx.info, f"agy step {step}: {message}")
+        except Exception:  # noqa: BLE001 - progress is best-effort
+            pass
+
+    return _run_agy_streamed(prompt, ws, continue_conv=False, timeout_s=timeout_s, on_progress=emit)
 
 
 @mcp.tool()

--- a/server.py
+++ b/server.py
@@ -89,6 +89,13 @@ mcp = FastMCP("agy")
 # set AGY_BRIDGE_DEBUG=1 for per-call diagnostics. See _configure_logging.
 log = logging.getLogger("agy_bridge")
 
+# The agy executable to invoke. Defaults to "agy" (resolved via PATH); set the
+# AGY_BIN env var to an explicit path when agy isn't reliably on PATH — e.g. on
+# Windows where a new terminal/reboot can drop it:
+#   AGY_BIN=%LOCALAPPDATA%\agy\bin\agy.exe
+# Read once at import; the launching process's environment wins.
+AGY_BIN = os.environ.get("AGY_BIN", "agy")
+
 AGY_DATA = Path.home() / ".gemini" / "antigravity-cli"
 LAST_CONVERSATIONS = AGY_DATA / "cache" / "last_conversations.json"
 BRAIN_DIR = AGY_DATA / "brain"
@@ -176,7 +183,7 @@ def _get_agy_version() -> Optional[str]:
     """Return `agy --version` output, or None if agy can't be run."""
     try:
         proc = subprocess.run(
-            ["agy", "--version"],
+            [AGY_BIN, "--version"],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
@@ -535,7 +542,7 @@ def _build_agy_args(
     is no agy flag that makes print mode safe; see the module docstring's SECURITY
     note.
     """
-    args = ["agy", "--print-timeout", f"{timeout_s}s"]
+    args = [AGY_BIN, "--print-timeout", f"{timeout_s}s"]
     pinned_conv: Optional[str] = None
     if continue_conv:
         # Pin to the exact conversation rooted at this workspace instead of `-c`

--- a/test_server.py
+++ b/test_server.py
@@ -282,6 +282,27 @@ def test_spawn_kwargs_is_subprocess_run_compatible(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# AGY_BIN  (configurable agy executable; AGY_BIN env var overrides "agy")
+# --------------------------------------------------------------------------
+
+
+def test_build_agy_args_uses_default_agy_bin(monkeypatch):
+    monkeypatch.setattr(server, "AGY_BIN", "agy")
+    args, _ = server._build_agy_args("hi", "C:\\ws", continue_conv=False, timeout_s=10)
+    assert args[0] == "agy"
+
+
+def test_build_agy_args_honors_custom_agy_bin(monkeypatch):
+    custom = "C:\\Users\\x\\AppData\\Local\\agy\\bin\\agy.exe"
+    monkeypatch.setattr(server, "AGY_BIN", custom)
+    args, _ = server._build_agy_args("hi", "C:\\ws", continue_conv=False, timeout_s=10)
+    assert args[0] == custom
+    # only argv[0] changes; the rest of the command line is unaffected
+    assert "--print-timeout" in args
+    assert args[-2:] == ["-p", "hi"]
+
+
+# --------------------------------------------------------------------------
 # _startup_checks  (composition of the tested helpers; agy version injected)
 # --------------------------------------------------------------------------
 

--- a/test_server.py
+++ b/test_server.py
@@ -224,7 +224,7 @@ def test_compat_warning_warns_for_newer_version():
     msg = server._compat_warning((1, 1, 0))
     assert msg is not None
     assert "1.1.0" in msg  # the detected version
-    assert "1.0.8" in msg  # the verified baseline it's compared to
+    assert "1.0.9" in msg  # the verified baseline it's compared to
 
 
 def test_compat_warning_none_when_version_unknown():
@@ -254,6 +254,34 @@ def test_debug_enabled_false_for_falsy(monkeypatch, value):
 
 
 # --------------------------------------------------------------------------
+# _spawn_kwargs  (console-detach so agy's TTY writes don't leak to the host)
+# --------------------------------------------------------------------------
+
+
+def test_spawn_kwargs_detaches_per_platform(monkeypatch):
+    monkeypatch.setattr(server.os, "name", "nt")
+    nt = server._spawn_kwargs()
+    # CREATE_NO_WINDOW == 0x08000000; reference the literal so the assertion is
+    # portable (the constant only exists on the Windows subprocess module).
+    assert nt == {"creationflags": 0x08000000}
+
+    monkeypatch.setattr(server.os, "name", "posix")
+    posix = server._spawn_kwargs()
+    assert posix == {"start_new_session": True}
+
+
+def test_spawn_kwargs_is_subprocess_run_compatible(monkeypatch):
+    # The returned mapping must be valid **kwargs for subprocess on this host
+    # (no platform-foreign keys leak through).
+    kwargs = server._spawn_kwargs()
+    assert isinstance(kwargs, dict)
+    if server.os.name == "nt":
+        assert "creationflags" in kwargs and "start_new_session" not in kwargs
+    else:
+        assert "start_new_session" in kwargs and "creationflags" not in kwargs
+
+
+# --------------------------------------------------------------------------
 # _startup_checks  (composition of the tested helpers; agy version injected)
 # --------------------------------------------------------------------------
 
@@ -266,7 +294,7 @@ def test_startup_checks_warns_on_newer_agy(monkeypatch, caplog):
 
 
 def test_startup_checks_silent_on_verified_agy(monkeypatch, caplog):
-    monkeypatch.setattr(server, "_get_agy_version", lambda: "1.0.8")
+    monkeypatch.setattr(server, "_get_agy_version", lambda: "1.0.9")
     caplog.set_level("WARNING", logger="agy_bridge")
     server._startup_checks()
     assert caplog.text == ""
@@ -422,6 +450,181 @@ def test_run_agy_args_include_print_timeout_and_prompt(fake_agy, brain_dir, last
     assert "42s" in args
     assert args[-2:] == ["-p", "my-prompt"]
     assert fake_agy["kwargs"]["cwd"] == "C:\\ws"
+
+
+# --------------------------------------------------------------------------
+# streaming: _entry_to_progress / _transcript_entries / _emit_new_progress
+# --------------------------------------------------------------------------
+
+
+def test_entry_to_progress_planner_first_line():
+    e = {"source": "MODEL", "type": "PLANNER_RESPONSE", "content": "narrate this\nand more"}
+    assert server._entry_to_progress(e) == "narrate this"
+
+
+def test_entry_to_progress_run_command_label():
+    e = {"source": "MODEL", "type": "RUN_COMMAND", "content": "Created At: ..."}
+    assert server._entry_to_progress(e) == "running a command…"
+
+
+def test_entry_to_progress_skips_user_and_system():
+    user = {"source": "USER_EXPLICIT", "type": "USER_INPUT", "content": "x"}
+    system = {"source": "SYSTEM", "type": "CONVERSATION_HISTORY"}
+    assert server._entry_to_progress(user) is None
+    assert server._entry_to_progress(system) is None
+
+
+def test_entry_to_progress_planner_without_content_is_none():
+    assert server._entry_to_progress({"source": "MODEL", "type": "PLANNER_RESPONSE"}) is None
+
+
+def test_transcript_entries_parses_and_skips_malformed(brain_dir):
+    _write_transcript(brain_dir, "te", ["{bad", "", _entry("PLANNER_RESPONSE", "ok")])
+    entries = server._transcript_entries("te")
+    assert len(entries) == 1
+    assert entries[0]["content"] == "ok"
+
+
+def test_transcript_entries_missing_returns_empty(brain_dir):
+    assert server._transcript_entries("nope") == []
+
+
+def test_progress_stream_pinned_skips_history_then_emits_fresh(brain_dir):
+    _write_transcript(
+        brain_dir,
+        "sc",
+        [_entry("PLANNER_RESPONSE", "history a"), _entry("PLANNER_RESPONSE", "history b")],
+    )
+    got = []
+    stream = server._ProgressStream("sc", time.time(), lambda s, m: got.append(m))
+    stream.poll()  # cursor starts past the two history entries
+    assert got == []
+    # a new entry lands for this turn (append to the existing transcript file)
+    transcript = brain_dir / "sc" / ".system_generated" / "logs" / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                _entry("PLANNER_RESPONSE", "history a"),
+                _entry("PLANNER_RESPONSE", "history b"),
+                _entry("PLANNER_RESPONSE", "fresh"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    stream.poll()
+    assert got == ["fresh"]  # only the post-baseline entry, history not replayed
+
+
+def test_progress_stream_new_conv_locks_on_and_ignores_others(brain_dir):
+    # a prior conversation already exists before the stream starts
+    _write_transcript(brain_dir, "old", [_entry("PLANNER_RESPONSE", "OLD STEP")])
+    start = time.time()
+    got = []
+    stream = server._ProgressStream(None, start, lambda s, m: got.append(m))  # snapshots {"old"}
+    # this run's new conversation appears after launch
+    _write_transcript(
+        brain_dir,
+        "new",
+        [_entry("PLANNER_RESPONSE", "NEW STEP"), _entry("RUN_COMMAND", "Created At: ...")],
+    )
+    os.utime(brain_dir / "new", (start + 5, start + 5))
+    stream.poll()
+    assert got == ["NEW STEP", "running a command…"]  # locked to 'new', 'old' ignored
+
+
+def test_progress_stream_new_conv_emits_nothing_without_new_conv(brain_dir):
+    _write_transcript(brain_dir, "old", [_entry("PLANNER_RESPONSE", "OLD STEP")])
+    got = []
+    stream = server._ProgressStream(None, time.time(), lambda s, m: got.append(m))
+    stream.poll()
+    assert got == []  # no brand-new conversation -> nothing
+
+
+# --------------------------------------------------------------------------
+# streaming: _run_agy_streamed (subprocess.Popen mocked)
+# --------------------------------------------------------------------------
+
+
+class _FakePopen:
+    def __init__(self, *a, polls=1, returncode=0, **k):
+        self._polls = polls
+        self.returncode = returncode
+
+    def poll(self):
+        if self._polls > 0:
+            self._polls -= 1
+            return None
+        return self.returncode
+
+    def communicate(self):
+        return ("", "")
+
+    def kill(self):
+        self.returncode = -9
+
+
+def test_run_agy_streamed_emits_progress_and_returns(monkeypatch, brain_dir, last_conv_file):
+    last_conv_file.write_text(json.dumps({"C:\\ws": "sc"}), encoding="utf-8")
+
+    def create_transcript():
+        # agy "writes" the transcript mid-run; it must appear AFTER the stream
+        # snapshots existing convs, so it's seen as this run's new conversation.
+        _write_transcript(
+            brain_dir,
+            "sc",
+            [
+                _entry("PLANNER_RESPONSE", "step one narration"),
+                _entry("RUN_COMMAND", "Created At: ..."),
+                _entry("PLANNER_RESPONSE", "final answer"),
+            ],
+        )
+        os.utime(brain_dir / "sc", (time.time() + 5, time.time() + 5))
+
+    class _CreatingPopen:
+        def __init__(self, *a, **k):
+            self.returncode = 0
+            self._n = 2
+
+        def poll(self):
+            self._n -= 1
+            if self._n == 1:
+                create_transcript()  # appears during the run
+            return None if self._n > 0 else self.returncode
+
+        def communicate(self):
+            return ("", "")
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **k: _CreatingPopen())
+    monkeypatch.setattr(server.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_RESPONSE_POLL_DEADLINE_S", 0.0)
+
+    progress = []
+    out = server._run_agy_streamed(
+        "hi",
+        "C:\\ws",
+        continue_conv=False,
+        timeout_s=10,
+        on_progress=lambda step, msg: progress.append(msg),
+    )
+    assert out == "final answer"
+    assert "step one narration" in progress
+    assert "running a command…" in progress
+
+
+def test_run_agy_streamed_nonzero_exit_raises(monkeypatch, brain_dir, last_conv_file):
+    last_conv_file.write_text(json.dumps({"C:\\ws": "sc"}), encoding="utf-8")
+    _write_transcript(brain_dir, "sc", [_entry("PLANNER_RESPONSE", "x")])
+    monkeypatch.setattr(
+        server.subprocess, "Popen", lambda *a, **k: _FakePopen(polls=0, returncode=1)
+    )
+    monkeypatch.setattr(server.time, "sleep", lambda *a, **k: None)
+    with pytest.raises(RuntimeError, match="agy exited 1"):
+        server._run_agy_streamed(
+            "hi", "C:\\ws", continue_conv=False, timeout_s=10, on_progress=lambda s, m: None
+        )
 
 
 # --------------------------------------------------------------------------

--- a/test_smoke.py
+++ b/test_smoke.py
@@ -9,6 +9,7 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 from server import (  # noqa: E402  (after stdout/stderr rewrap above)
     _detect_image_format,
+    _run_agy_streamed,
     agy_ask,
     agy_continue,
     agy_image,
@@ -47,6 +48,28 @@ def main() -> int:
     final = result.splitlines()[0].strip()
     assert os.path.isfile(final), f"image not found: {final}"
     assert _detect_image_format(final), f"not a recognized image: {final}"
+    print("PASS")
+
+    print("\n=== smoke 4: agy_ask_stream emits live progress ===")
+    ticks = []
+
+    def on_progress(step, message):
+        ticks.append((step, message))
+        print(f"  [progress {step}] {message}")
+
+    t0 = time.time()
+    resp4 = _run_agy_streamed(
+        "Use python to compute 6*7, print it, then reply with ONLY the number.",
+        os.getcwd(),
+        continue_conv=False,
+        timeout_s=180,
+        on_progress=on_progress,
+    )
+    print(f"elapsed: {time.time() - t0:.1f}s")
+    print(f"response ({len(resp4)} chars): {resp4!r}")
+    print(f"progress ticks: {len(ticks)}")
+    assert resp4.strip(), "empty response"
+    assert ticks, "no progress ticks emitted"
     print("PASS")
 
     return 0


### PR DESCRIPTION
## Summary

Re-verifies the bridge against **agy 1.0.9** and ships three changes.

### 🖥️ Console-detach leak fix
`agy -p` writes its progress/answer to the **controlling terminal**, not its stdout fd — so under a TUI that text leaked into the host''s prompt input (observed live on 1.0.9). The bridge now spawns agy detached from the terminal (`_spawn_kwargs`: `CREATE_NO_WINDOW` on Windows / a new POSIX session); the answer is still read from the transcript.

### 🧪 Experimental streaming progress (`agy_ask_stream`)
New tool that surfaces agy''s intermediate steps (planner narration + tool runs) as MCP **progress notifications**, read live from the transcript. Coarse by nature — agy flushes the transcript in chunks — and `_ProgressStream` locks onto this run''s conversation so other runs'' output can''t bleed in.

### 🌐 `AGY_BIN` env-var fallback
Set `AGY_BIN` to an explicit path (e.g. `%LOCALAPPDATA%\agy\bin\agy.exe`) when `agy` isn''t reliably on `PATH` — the Windows stale-PATH case diagnosed by `@fallout`''s Qiita write-ups (credited in the new README acknowledgments section).

## Verification
- Re-verified on agy 1.0.9: `-p` still writes nothing to stdout; all Security claims still hold (out-of-workspace writes; `--sandbox` leaves `write_to_file` open; a blocked-sandbox run writes no JSONL transcript, only the `.db`).
- Offline suite: **97 passed**; `ruff check .` clean; format clean.
- Live smoke: **4/4** (ask / continue / image / stream).

## Notes
- `VERIFIED_AGY_VERSION` → 1.0.9; package version 0.4.2 → **0.5.0** (new public tool).
- `agy_ask_stream` progress *delivery* hasn''t been observed in a live Claude Code client yet — verified at function level + smoke ticks. Whether the client surfaces progress/log notifications is client-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)